### PR TITLE
Avoid unnecessary tests

### DIFF
--- a/run-jmh-perfasm.sh
+++ b/run-jmh-perfasm.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+JAR=build/libs/cuckoohash-1.0-SNAPSHOT-jmh.jar
+
+java \
+  -jar $JAR ".*cuckoohash.*" -wi 4 -i 4 -r 1 -f 1 -prof perfasm | tee jmh.log

--- a/src/main/java/com/github/kratorius/cuckoohash/CuckooHashMap.java
+++ b/src/main/java/com/github/kratorius/cuckoohash/CuckooHashMap.java
@@ -214,13 +214,12 @@ public class CuckooHashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> 
     MapEntry<V> v1 = T1[hashFunction1.hash(actualKey)];
     MapEntry<V> v2 = T2[hashFunction2.hash(actualKey)];
 
-    if (v1 == null && v2 == null) {
-      return defaultValue;
-    } else if (v1 != null && v1.key.equals(actualKey)) {
+    if (v1 != null && v1.key.equals(actualKey)) {
       return v1.value;
     } else if (v2 != null && v2.key.equals(actualKey)) {
       return v2.value;
     }
+
     return defaultValue;
   }
 

--- a/src/main/java/com/github/kratorius/cuckoohash/CuckooHashMap.java
+++ b/src/main/java/com/github/kratorius/cuckoohash/CuckooHashMap.java
@@ -209,14 +209,15 @@ public class CuckooHashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> 
   }
 
   private V get(Object key, V defaultValue) {
-    Object actualKey = (key != null ? key : KEY_NULL);
+    Object actualKey = key != null ? key : KEY_NULL;
 
     MapEntry<V> v1 = T1[hashFunction1.hash(actualKey)];
-    MapEntry<V> v2 = T2[hashFunction2.hash(actualKey)];
-
     if (v1 != null && v1.key.equals(actualKey)) {
       return v1.value;
-    } else if (v2 != null && v2.key.equals(actualKey)) {
+    }
+
+    MapEntry<V> v2 = T2[hashFunction2.hash(actualKey)];
+    if (v2 != null && v2.key.equals(actualKey)) {
       return v2.value;
     }
 


### PR DESCRIPTION
Skip implicit `null` tests and do not compute `h_T2(x)` unless necessary.

This improves performance on `get()` by ~25mln ops/s. Still not as good as java's hashmap but getting closer.

```
Benchmark                        Mode  Cnt          Score         Error  Units
JMHGet.measureGetCuckooHashMap  thrpt   32  125157907.243 ± 1702893.594  ops/s
JMHGet.measureGetHashMap        thrpt   32  145409047.889 ± 2380627.294  ops/s
```

At this point I suspect that the problem is either the hash function or cache misses (since we jump from T1 to T2 all the time, but that shouldn't be such a big deal given how big the tables are, right?). And there's always the possibility that I'm not measuring what I think I'm measuring on JMH. So the investigation continues.
